### PR TITLE
Duplicated Code in BaseDatabaseInstance _Save<TKey> method

### DIFF
--- a/Wintellect.Sterling.Core/Database/BaseDatabaseInstance.cs
+++ b/Wintellect.Sterling.Core/Database/BaseDatabaseInstance.cs
@@ -558,12 +558,7 @@ namespace Wintellect.Sterling.Core.Database
             if ( cache.Check( instance ) )
             {
                 return key;
-            }
-
-            if ( cache.Check( instance ) )
-            {
-                return key;
-            }
+            } 
 
             cache.Add( tableType, instance, key );
 


### PR DESCRIPTION
Code below was duplicated lines 563-566

if ( cache.Check( instance ) )
{
return key;
}
